### PR TITLE
Unescape XML entities ourselves 'cause Oracle's lib doesn't

### DIFF
--- a/code/wsdl2plsql/src/br/gov/serpro/wsdl2pl/writer/FunctionBodyWriter.java
+++ b/code/wsdl2plsql/src/br/gov/serpro/wsdl2pl/writer/FunctionBodyWriter.java
@@ -539,7 +539,7 @@ public class FunctionBodyWriter extends BaseWriter
                     : ".getStringVal()";
 
             body.l(level + 1, "%s := %s;", prefix + name,
-                    U.stringToBaseType(type.getXsdType().getLocalPart(), varTempNode.name() + extractionMethod));
+                    U.stringToBaseType(type.getXsdType().getLocalPart(), "dbms_xmlgen.convert(" + varTempNode.name() + extractionMethod + ", dbms_xmlgen.entity_decode)"));
             // END IF;
             body.l(level, "%s %s;", ke.end(), ke.ifKey());
         }


### PR DESCRIPTION
Oracle's [docs](http://docs.oracle.com/cd/B12037_01/appdev.101/b10790/xdb04cre.htm#sthref341) state that `getStringVal()` does not unescape XML entities. When we use it without unescaping them ourselves, entities can "bleed out" of our generated clients.

Example server response:

```
<?xml version='1.0' encoding='UTF-8'?>
<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
  <soap:Body>
    <ns2:example-response xmlns:ns2="http://example.org/">
      <inner-xml>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;micro-xml /&gt;</inner-xml>
    </ns2:example-response>
  </soap:Body>
</soap:Envelope">
```

We should get:

```
<?xml version="1.0" encoding="UTF-8"?><micro-xml />
```

What we get (without the PR) is:

```
&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;micro-xml /&gt;
```

The PR fixes this problem.
