### PR TITLE
Do not restrict `xs:string` to varchar2

### DIFF
--- a/code/wsdl2plsql/src/br/gov/serpro/wsdl2pl/util/U.java
+++ b/code/wsdl2plsql/src/br/gov/serpro/wsdl2pl/util/U.java
@@ -94,10 +94,12 @@ public class U
     {
         String plType = null;
 
-        String[] stringTypes = { "string", "ENTITIES", "ENTITY", "ID", "IDREF", "IDREFS", "language", "Name", "NCName",
+        String[] stringTypes = { "ENTITIES", "ENTITY", "ID", "IDREF", "IDREFS", "language", "Name", "NCName",
                 "NMTOKEN", "NMTOKENS", "normalizedString", "QName", "token" };
 
-        String[] longStringTypes = { "base64Binary" };
+        String[] longStringTypes = { "string" };
+
+        String[] binaryTypes = { "base64Binary" };
 
         String[] dateTypes = { "date", "dateTime", "time" };
 
@@ -117,6 +119,10 @@ public class U
             plType = ke.varchar2() + s;
         }
         else if (Arrays.asList(longStringTypes).contains(xsdType))
+        {
+            plType = ke.clob();
+        }
+        else if (Arrays.asList(binaryTypes).contains(xsdType))
         {
             plType = ke.blob();
         }

--- a/code/wsdl2plsql/src/br/gov/serpro/wsdl2pl/writer/FunctionBodyWriter.java
+++ b/code/wsdl2plsql/src/br/gov/serpro/wsdl2pl/writer/FunctionBodyWriter.java
@@ -535,11 +535,8 @@ public class FunctionBodyWriter extends BaseWriter
                     ke.then());
 
             // var := (tempNode.stringVal());
-            String extractionMethod = type.getXsdType().getLocalPart().equalsIgnoreCase("base64binary") ? ".getClobVal()"
-                    : ".getStringVal()";
-
             body.l(level + 1, "%s := %s;", prefix + name,
-                    U.stringToBaseType(type.getXsdType().getLocalPart(), "dbms_xmlgen.convert(" + varTempNode.name() + extractionMethod + ", dbms_xmlgen.entity_decode)"));
+                    U.stringToBaseType(type.getXsdType().getLocalPart(), "dbms_xmlgen.convert(" + varTempNode.name() + ".getClobVal()" + ", dbms_xmlgen.entity_decode)"));
             // END IF;
             body.l(level, "%s %s;", ke.end(), ke.ifKey());
         }


### PR DESCRIPTION
`varchar2` is an Oracle datatype limited to 32k. On the other side, `xs:string` is unlimited in size when not specified. Mapping `xs:string` to `varchar2` may lead to buffer limit problems. This PR fixes that.
