### PR TITLE
Change escaping approach to avoid issues when CDATA end delimiter app…

### DIFF
--- a/code/wsdl2plsql/src/br/gov/serpro/wsdl2pl/util/U.java
+++ b/code/wsdl2plsql/src/br/gov/serpro/wsdl2pl/util/U.java
@@ -167,7 +167,7 @@ public class U
         TO_MASKS.put("double", "TRIM(TO_CHAR($var, '9999999999.99'))");
         TO_MASKS.put("float", "TRIM(TO_CHAR($var, '9999999999.99'))");
         TO_MASKS.put("base64binary", "encode_base64($var)");
-        TO_MASKS.put("string", "<[!CDATA[ $var ]]>)");
+        TO_MASKS.put("string", "dbms_xmlgen.convert($var, dbms_xmlgen.entity_encode)");
 
         FROM_MASKS.put("decimal", "TO_NUMBER($var, '9999999999.99')");
         FROM_MASKS.put("boolean", "CASE LOWER($var) WHEN 'true' THEN true ELSE false END");


### PR DESCRIPTION
I found a character concatenation problem that was causing compilation errors in the generated PL/SQL code. However, instead of just making a syntax correction I decided to use XML Entities to avoid issues that may arise when a CDATA end delimiter appears in the middle of a String.

Reference: http://stackoverflow.com/questions/223652/is-there-a-way-to-escape-a-cdata-end-token-in-xml
