### PR TITLE
Raise soap faultstring with PL/SQL error

### DIFF
--- a/code/wsdl2plsql/src/main/java/br/gov/serpro/wsdl2pl/parser/TypesParser.java
+++ b/code/wsdl2plsql/src/main/java/br/gov/serpro/wsdl2pl/parser/TypesParser.java
@@ -92,6 +92,7 @@ public class TypesParser
         dissectComplexType(soapFaultComplexType);
 
         Exception soapFaultException = new Exception(context, new ElementInfo("SoapFault"));
+        soapFaultException.setNumber(context.nextExceptionId());
         soapFaultException.setType(new ComplexTypeDef(context, soapFaultComplexType.getQname()));
 
         context.registerSoapFaultException(soapFaultException);

--- a/code/wsdl2plsql/src/main/java/br/gov/serpro/wsdl2pl/writer/FunctionBodyWriter.java
+++ b/code/wsdl2plsql/src/main/java/br/gov/serpro/wsdl2pl/writer/FunctionBodyWriter.java
@@ -257,8 +257,16 @@ public class FunctionBodyWriter extends BaseWriter
         }
         else
         {
-            // RAISE err_fault
-            body.l(INDENT + 2, "%s %s;\n", ke.raise(), getContext().getSoapFaultException().name());
+        	String exceptionRecordName = getContext().getSoapFaultException().varName();
+        	
+        	String exceptionTypeId = getContext().getSoapFaultException().getType().getId();
+
+        	RecordType exceptionRecordType = (RecordType) getContext().getCustomType(exceptionTypeId);
+        	
+        	String faultStringfieldName = exceptionRecordType.getMembers().get(1).name();
+        	
+        	// RAISE err_fault
+            body.l(INDENT + 2, "raise_application_error(%d, %s.%s);\n", getContext().getSoapFaultException().getNumber(), exceptionRecordName, faultStringfieldName);
         }
 
         // END IF;

--- a/code/wsdl2plsql/src/main/java/br/gov/serpro/wsdl2pl/writer/SpecWriter.java
+++ b/code/wsdl2plsql/src/main/java/br/gov/serpro/wsdl2pl/writer/SpecWriter.java
@@ -54,16 +54,20 @@ public class SpecWriter extends BaseWriter
             {
                 spec.l(1, "-- %s", exception.comments());
                 spec.l(1, "%s;", exception.decl());
-                if (exception.getType() != null)
+                if (exception.getType() != null || exception.getNumber() != null)
                 {
-                    // err_name EXCEPTION;
-                    spec.l(1, "%s;\n", exception.var());
-                }
-                else if (exception.getNumber() != null)
-                {
-                    // PRAGMA EXCEPTION_INIT(err_name, -20000);
-                    spec.l(1, "%s %s(%s, %d);\n", ke.pragma(), ke.exceptionInit(), exception.name(),
-                            exception.getNumber());
+                    if (exception.getType() != null)
+                    {
+                        // err_name EXCEPTION;
+                        spec.l(1, "%s;\n", exception.var());
+                    }
+
+                    if (exception.getNumber() != null)
+                    {
+                        // PRAGMA EXCEPTION_INIT(err_name, -20000);
+                        spec.l(1, "%s %s(%s, %d);\n", ke.pragma(), ke.exceptionInit(), exception.name(),
+                                exception.getNumber());
+                    }
                 }
                 else
                 {

--- a/code/wsdl2plsql/src/test/java/br/gov/serpro/wsdl2pl/writer/FunctionBodyWriterTest.java
+++ b/code/wsdl2plsql/src/test/java/br/gov/serpro/wsdl2pl/writer/FunctionBodyWriterTest.java
@@ -2,6 +2,9 @@ package br.gov.serpro.wsdl2pl.writer;
 
 import static org.junit.Assert.*;
 
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
+
 import java.io.IOException;
 
 import org.junit.Test;
@@ -11,6 +14,10 @@ import com.predic8.wsdl.WSDLParser;
 
 import br.gov.serpro.wsdl2pl.Context;
 import br.gov.serpro.wsdl2pl.emitter.impl.DefaultKeywordEmitter;
+import br.gov.serpro.wsdl2pl.emitter.impl.DefaultSymbolNameEmitter;
+import br.gov.serpro.wsdl2pl.parser.OperationsParser;
+import br.gov.serpro.wsdl2pl.parser.TypesParser;
+import br.gov.serpro.wsdl2pl.util.K;
 
 public class FunctionBodyWriterTest {
 
@@ -33,11 +40,41 @@ public class FunctionBodyWriterTest {
 
 		assertFalse("Output should not contain debugging (dbms_output) calls", output.contains("dbms_output"));
 	}
+	
+	@Test
+	public void shouldProvideSoapFaultMessageInSqlErrm() throws IOException {
+		Context context = makeContext();
+		
+		final String output = new FunctionBodyWriter(context).write();
+		
+		final String expected = "raise_application_error(-20001, ex_soap_fault.m_faultstring);";
+		
+		assertThat(output, containsString(expected));
+	}
 
 	private Context makeContext() {
-		Definitions defs = new WSDLParser().parse(getClass().getClassLoader().getResourceAsStream("sample-service.wsdl"));
-		Context c = new Context(defs);
-        c.setKeywordEmitter(new DefaultKeywordEmitter());
-		return c;
+        WSDLParser parser = new WSDLParser();
+
+        Definitions defs = parser.parse(Thread.currentThread().getContextClassLoader().getResourceAsStream("sample-service.wsdl"));
+
+        Context context = new Context(defs);
+
+        context.setServices(new String[] {"Calculator"});
+        context.setPackageName("pk_sample");
+        context.resolveProtocol(K.Protocol.SOAP_1_2);
+        context.setDebuggingMode(false);
+
+        context.setKeywordEmitter(new DefaultKeywordEmitter());
+        context.setSymbolNameEmitter(new DefaultSymbolNameEmitter());
+
+        TypesParser typesParser = new TypesParser(context);
+        typesParser.parse();
+
+        OperationsParser operationsParser = new OperationsParser(context);
+        operationsParser.parse();
+        
+        context.makeElegible("ws_addRequestType");
+		
+        return context;
 	}
 }

--- a/code/wsdl2plsql/src/test/resources/sample-service.wsdl
+++ b/code/wsdl2plsql/src/test/resources/sample-service.wsdl
@@ -1,27 +1,40 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <definitions xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="http://www.oracle-base.com/webservices/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns="http://schemas.xmlsoap.org/wsdl/" targetNamespace="http://www.oracle-base.com/webservices/">
 <types>
-<xsd:schema targetNamespace="http://www.oracle-base.com/webservices/"
->
+<xsd:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.oracle-base.com/webservices/">
+  <xs:element name="ws_addRequestType" type="tns:ws_addResponseType" />
+  <xs:element name="ws_addResponseType" type="tns:ws_addResponseType" />
+  <xs:complexType name="ws_addRequestType">
+    <xs:sequence>
+      <xs:element minOccurs="1" maxOccurs="1" name="int1" type="xs:short"/>
+      <xs:element minOccurs="1" maxOccurs="1" name="int2" type="xs:short"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="ws_addResponseType">
+    <xs:sequence>
+      <xs:element minOccurs="1" maxOccurs="1" name="int1" type="xs:short"/>
+    </xs:sequence>
+  </xs:complexType>
 </xsd:schema>
 </types>
 <message name="ws_addRequest">
-  <part name="int1" type="xsd:string" />
-  <part name="int2" type="xsd:string" /></message>
+  <part element="tns:ws_addRequestType" name="parameters" />
+</message>
 <message name="ws_addResponse">
-  <part name="return" type="xsd:string" /></message>
+  <part element="tns:ws_addResponseType" name="parameters" />
+</message>
 <portType name="CalculatorPortType">
   <operation name="ws_add">
-    <input message="tns:ws_addRequest"/>
-    <output message="tns:ws_addResponse"/>
+    <input message="tns:ws_addRequest" name="tns:ws_addRequest" />
+    <output message="tns:ws_addResponse" name="tns:ws_addResponse"/>
   </operation>
 </portType>
 <binding name="CalculatorBinding" type="tns:CalculatorPortType">
-  <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+  <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
   <operation name="ws_add">
-    <soap:operation soapAction="https://oracle-base.com/webservices/server.php/ws_add" style="rpc"/>
-    <input><soap:body use="encoded" namespace="http://www.oracle-base.com/webservices/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></input>
-    <output><soap:body use="encoded" namespace="http://www.oracle-base.com/webservices/" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"/></output>
+    <soap:operation soapAction="https://oracle-base.com/webservices/server.php/ws_add" style="document"/>
+    <input><soap:body use="literal" /></input>
+    <output><soap:body use="literal" /></output>
   </operation>
 </binding>
 <service name="Calculator">


### PR DESCRIPTION
Changes fault string treatment from:

```sql
-- extract value of faultstring
wl_temp_node := wl_response.extract('/SOAP-ENV:Envelope/SOAP-ENV:Body/SOAP-ENV:Fault/faultstring/child::node()', wl_ns_map);
IF wl_temp_node IS NOT NULL THEN
    ex_soap_fault.m_faultstring := dbms_xmlgen.convert(wl_temp_node.getClobVal(), dbms_xmlgen.entity_decode);
END IF;

RAISE err_soap_fault; -- removed
```

to 

```sql
-- extract value of faultstring
wl_temp_node := wl_response.extract('/SOAP-ENV:Envelope/SOAP-ENV:Body/SOAP-ENV:Fault/faultstring/child::node()', wl_ns_map);
IF wl_temp_node IS NOT NULL THEN
    ex_soap_fault.m_faultstring := dbms_xmlgen.convert(wl_temp_node.getClobVal(), dbms_xmlgen.entity_decode);
END IF;

raise_application_error(-20001, ex_soap_fault.m_faultstring); -- added
```
This allows downstream code to access the SOAP Fault String using the usual `sqlerrm` mechanism.