### PR TITLE
Better error messages for server failures

### DIFF
--- a/code/wsdl2plsql/src/main/java/br/gov/serpro/wsdl2pl/Context.java
+++ b/code/wsdl2plsql/src/main/java/br/gov/serpro/wsdl2pl/Context.java
@@ -62,6 +62,8 @@ public class Context
 
     private String inputValidationExceptionId;
 
+    private String xmlParsingExceptionId;
+
     private Map<String, String> namespacePrefixes = new HashMap<String, String>();
 
     private int exceptionId = 20000;
@@ -341,6 +343,16 @@ public class Context
     {
         return exceptions.get(inputValidationExceptionId);
     }
+
+    public void registerXmlParsingException(Exception exception)
+    {
+        registerException(exception);
+        xmlParsingExceptionId = exception.getId();
+    }
+
+    public Exception getXmlParsingException() {
+        return exceptions.get(xmlParsingExceptionId);
+	}
 
     public void resolveProtocol(String preferredProtocol)
     {

--- a/code/wsdl2plsql/src/main/java/br/gov/serpro/wsdl2pl/parser/TypesParser.java
+++ b/code/wsdl2plsql/src/main/java/br/gov/serpro/wsdl2pl/parser/TypesParser.java
@@ -102,6 +102,10 @@ public class TypesParser
         Exception inputValidationException = new Exception(context, new ElementInfo("InputValidation"));
         inputValidationException.setNumber(context.nextExceptionId());
         context.registerInputValidationException(inputValidationException);
+
+        Exception xmlParsingException = new Exception(context, new ElementInfo("XmlParsing"));
+        xmlParsingException.setNumber(-31011);
+        context.registerXmlParsingException(xmlParsingException);
     }
 
     private ComplexType buildSoap11FaultComplexType()

--- a/code/wsdl2plsql/src/main/resources/util-functions.txt.mustache
+++ b/code/wsdl2plsql/src/main/resources/util-functions.txt.mustache
@@ -25,13 +25,14 @@
     END fc_print_long_clob;
   {{/debugging?}}
 
-    FUNCTION fc_post
+    PROCEDURE pr_post
     (
         wp_url IN VARCHAR2,
         wp_data IN CLOB,
-        wp_soap_action VARCHAR2 DEFAULT NULL
+        wp_soap_action VARCHAR2 DEFAULT NULL,
+        wp_response_status OUT INTEGER,
+        wp_response_body OUT CLOB
     )
-        RETURN CLOB
     IS
         --
         wl_request  utl_http.req;
@@ -77,6 +78,7 @@
 
         -- get response
         wl_response := utl_http.get_response(wl_request);
+        wp_response_status := wl_response.status_code;
         dbms_lob.createtemporary(wl_buffer, FALSE);
         BEGIN
             LOOP
@@ -97,9 +99,9 @@
         END IF;
       {{/debugging?}}
 
-        RETURN wl_buffer;
+        wp_response_body := wl_buffer;
 
-    END fc_post;
+    END pr_post;
 
     FUNCTION fc_to_date(
         wp_string varchar2

--- a/code/wsdl2plsql/src/test/java/br/gov/serpro/wsdl2pl/writer/FunctionBodyWriterTest.java
+++ b/code/wsdl2plsql/src/test/java/br/gov/serpro/wsdl2pl/writer/FunctionBodyWriterTest.java
@@ -52,6 +52,25 @@ public class FunctionBodyWriterTest {
 		assertThat(output, containsString(expected));
 	}
 
+	@Test
+	public void handleParsingErrors() throws IOException {
+        // Target code:
+        // pr_post(wp_url, wl_request, '', wl_response_status, wl_response_text);
+        // begin
+        //     wl_response := XMLTYPE.createXml(wl_response_text);
+        // exception
+        //     when err_xml_parsing then
+        //         raise_application_error(-20001, 'HTTP request failed with status ' || wl_response_status);
+        // end;
+		Context context = makeContext();
+
+		final String output = new FunctionBodyWriter(context).write();
+
+		assertThat(output, containsString("pr_post(wp_url, wl_request, 'https://oracle-base.com/webservices/server.php/ws_add', wl_response_status, wl_response_text)"));
+		assertThat(output, containsString("when err_xml_parsing then"));
+		assertThat(output, containsString("raise_application_error(-20001, 'HTTP request failed with status ' || wl_response_status)"));
+	}
+
 	private Context makeContext() {
         WSDLParser parser = new WSDLParser();
 


### PR DESCRIPTION
Currently when sending a service request from the generated client to a misconfigured server, the error message says "ORA-31011: XML parsing failed", which is misleading.

This change clients to output "HTTP request failed with status 502" instead.